### PR TITLE
adds padding method

### DIFF
--- a/example/getting-started.md
+++ b/example/getting-started.md
@@ -19,6 +19,7 @@ And finally, this is how that data array would be passed to the [textBox](http:/
 new d3plus.TextBox()
   .data(data)
   .fontSize(16)
+  .padding("10 20")
   .width(200)
   .x(function(d, i) { return i * 250; })
   .render();

--- a/package-lock.json
+++ b/package-lock.json
@@ -1268,9 +1268,9 @@
       }
     },
     "d3plus-common": {
-      "version": "0.6.31",
-      "resolved": "https://registry.npmjs.org/d3plus-common/-/d3plus-common-0.6.31.tgz",
-      "integrity": "sha512-lZ4FpC+92CKfGr4tYJGN0+moRrPZlvrZbsBoxJumlyu7TXshJQZYHOaik1T/LiEsnoLNA6KWqniUP+NArfRsuQ==",
+      "version": "0.6.33",
+      "resolved": "https://registry.npmjs.org/d3plus-common/-/d3plus-common-0.6.33.tgz",
+      "integrity": "sha512-EUth74X/D7ik1iRT3ErpFD+DTxak0Sh2gb2gLe/O8ysOBtTFvtdU/vyaHKoc8VHFnXDu5zEH0ZzNwJY3AVX0sg==",
       "requires": {
         "d3-array": "1.2.1",
         "d3-collection": "1.0.4",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "d3-array": "^1.2.0",
     "d3-selection": "^1.3.0",
     "d3-transition": "^1.1.0",
-    "d3plus-common": "^0.6.31"
+    "d3plus-common": "^0.6.33"
   },
   "scripts": {
     "build": "d3plus-build",

--- a/src/TextBox.js
+++ b/src/TextBox.js
@@ -47,6 +47,7 @@ export default class TextBox extends BaseClass {
     this._id = (d, i) => d.id || `${i}`;
     this._on = {};
     this._overflow = constant(false);
+    this._padding = constant(0);
     this._pointerEvents = constant("auto");
     this._rotate = constant(0);
     this._split = textSplit;
@@ -91,8 +92,8 @@ export default class TextBox extends BaseClass {
         "line-height": lH
       };
 
-      const h = this._height(d, i),
-            w = this._width(d, i);
+      const h = this._height(d, i) - (this._padding() * 2),
+            w = this._width(d, i) - (this._padding() * 2);
 
       const wrapper = wrap()
         .fontFamily(style["font-family"])
@@ -191,7 +192,7 @@ export default class TextBox extends BaseClass {
           id: this._id(d, i),
           tA: this._textAnchor(d, i),
           widths: wrapResults.widths,
-          fS, lH, w, h, x: this._x(d, i), y: this._y(d, i) + yP
+          fS, lH, w, h, x: this._x(d, i) + this._padding(), y: this._y(d, i) + yP + this._padding()
         });
 
       }
@@ -446,6 +447,15 @@ function(d, i) {
   */
   overflow(_) {
     return arguments.length ? (this._overflow = typeof _ === "function" ? _ : constant(_), this) : this._overflow;
+  }
+
+  /**
+  @memberof TextBox
+  @desc Sets the padding to the specified accessor function or static number, which is 0 by default.
+  @param {Function|Number} [*value*]
+  */
+  padding(_) {
+    return arguments.length ? (this._padding = typeof _ === "function" ? _ : constant(_), this) : this._padding;
   }
 
   /**

--- a/src/TextBox.js
+++ b/src/TextBox.js
@@ -7,7 +7,7 @@ import {select} from "d3-selection";
 import {transition} from "d3-transition";
 import {max, min, sum} from "d3-array";
 
-import {accessor, BaseClass, constant} from "d3plus-common";
+import {accessor, BaseClass, constant, parseSides} from "d3plus-common";
 
 import fontExists from "./fontExists";
 import {default as detectRTL} from "./rtl";
@@ -92,8 +92,10 @@ export default class TextBox extends BaseClass {
         "line-height": lH
       };
 
-      const h = this._height(d, i) - (this._padding() * 2),
-            w = this._width(d, i) - (this._padding() * 2);
+      const padding = parseSides(this._padding(d, i));
+
+      const h = this._height(d, i) - (padding.top + padding.bottom),
+            w = this._width(d, i) - (padding.left + padding.right);
 
       const wrapper = wrap()
         .fontFamily(style["font-family"])
@@ -192,7 +194,9 @@ export default class TextBox extends BaseClass {
           id: this._id(d, i),
           tA: this._textAnchor(d, i),
           widths: wrapResults.widths,
-          fS, lH, w, h, x: this._x(d, i) + this._padding(), y: this._y(d, i) + yP + this._padding()
+          fS, lH, w, h,
+          x: this._x(d, i) + padding.left,
+          y: this._y(d, i) + yP + padding.top
         });
 
       }
@@ -450,9 +454,9 @@ function(d, i) {
   }
 
   /**
-  @memberof TextBox
-  @desc Sets the padding to the specified accessor function or static number, which is 0 by default.
-  @param {Function|Number} [*value*]
+      @memberof TextBox
+      @desc Sets the padding to the specified accessor function, CSS shorthand string, or static number, which is 0 by default.
+      @param {Function|Number|String} [*value*]
   */
   padding(_) {
     return arguments.length ? (this._padding = typeof _ === "function" ? _ : constant(_), this) : this._padding;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

### Description
Adds the padding method to the TextBox class, which allows for padding values (like in CSS) to be applied to rendered text boxes. (closes #18)

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have documented all new methods.
- [ ] I have written tests for all new methods/functionality.
- [x] I have written examples for all new methods/functionality.

