### PR TITLE
Clarifies font size description in docs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "d3plus-text",
-  "version": "0.9.25",
+  "version": "0.9.26",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/TextBox.js
+++ b/src/TextBox.js
@@ -366,7 +366,7 @@ function(text, line) {
 
   /**
       @memberof TextBox
-      @desc Sets the maximum font size to the specified accessor function or static number, which is used when [dynamically resizing fonts](#textBox.fontResize).
+      @desc Sets the maximum font size to the specified accessor function or static number (which corresponds to pixel units), which is used when [dynamically resizing fonts](#textBox.fontResize).
       @param {Function|Number} [*value* = 50]
   */
   fontMax(_) {
@@ -375,7 +375,7 @@ function(text, line) {
 
   /**
       @memberof TextBox
-      @desc Sets the minimum font size to the specified accessor function or static number, which is used when [dynamically resizing fonts](#textBox.fontResize).
+      @desc Sets the minimum font size to the specified accessor function or static number (which corresponds to pixel units), which is used when [dynamically resizing fonts](#textBox.fontResize).
       @param {Function|Number} [*value* = 8]
   */
   fontMin(_) {
@@ -393,7 +393,7 @@ function(text, line) {
 
   /**
       @memberof TextBox
-      @desc Sets the font size to the specified accessor function or static number, which is inferred from the [DOM selection](#textBox.select) by default.
+      @desc Sets the font size to the specified accessor function or static number (which corresponds to pixel units), which is inferred from the [DOM selection](#textBox.select) by default.
       @param {Function|Number} [*value* = 10]
   */
   fontSize(_) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->
This updates the description for font size in the docs to specify that the static number corresponds to a value in pixel units. (closes #79)
### Description
<!--- Describe your changes in detail -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have documented all new methods.
- [ ] I have written tests for all new methods/functionality.
- [ ] I have written examples for all new methods/functionality.

