### PR TITLE
fixes the lineHeight fontResize bug

### DIFF
--- a/src/TextBox.js
+++ b/src/TextBox.js
@@ -78,9 +78,10 @@ export default class TextBox extends BaseClass {
       if (t === void 0) return arr;
 
       const resize = this._fontResize(d, i);
+      const lHRatio = this._lineHeight(d, i) / this._fontSize(d, i);
 
       let fS = resize ? this._fontMax(d, i) : this._fontSize(d, i),
-          lH = resize ? fS * 1.4 : this._lineHeight(d, i),
+          lH = resize ? fS * lHRatio : this._lineHeight(d, i),
           line = 1,
           lineData = [],
           sizes,
@@ -125,7 +126,7 @@ export default class TextBox extends BaseClass {
         else if (fS > fMax) fS = fMax;
 
         if (resize) {
-          lH = fS * 1.4;
+          lH = fS * lHRatio;
           wrapper
             .fontSize(fS)
             .lineHeight(lH);


### PR DESCRIPTION
(closes #83 )

<!--- Provide a general summary of your changes in the title above -->

### Description
<!--- Describe your changes in detail -->
The bug was caused by `lineHeight` being set to `fontSize * 1.4` when `fontResize` is `true` in [TextBox.js](https://github.com/d3plus/d3plus-text/blob/master/src/TextBox.js#L83). To preserve the `lineHeight` to `fontSize` ratio when the font is resized, I calculate `ratio = lineHeight / fontSize` and then set `lineHeight` to `fontSize * ratio` when `fontResize` is `true`.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have documented all new methods.
- [ ] I have written tests for all new methods/functionality.
- [ ] I have written examples for all new methods/functionality.

