### PR TITLE
adds rotationAnchor method to TextBox

### DIFF
--- a/src/TextBox.js
+++ b/src/TextBox.js
@@ -226,7 +226,7 @@ export default class TextBox extends BaseClass {
     }
 
     function rotate(text) {
-      text.attr("transform", (d, i) => `translate(${d.x}, ${d.y}) rotate(${that._rotate(d, i)}, ${that._rotationAnchor && that._rotationAnchor(d, i) ? that._rotationAnchor(d, i)[0] : d.w / 2}, ${that._rotationAnchor && that._rotationAnchor(d, i) ? that._rotationAnchor(d, i)[1] : d.h / 2})`);
+      text.attr("transform", (d, i) => `translate(${d.x}, ${d.y}) rotate(${that._rotate(d, i)}, ${that._rotateAnchor && that._rotateAnchor(d, i) ? that._rotateAnchor(d, i)[0] : d.w / 2}, ${that._rotateAnchor && that._rotateAnchor(d, i) ? that._rotateAnchor(d, i)[1] : d.h / 2})`);
     }
 
     const update = boxes.enter().append("g")
@@ -500,8 +500,8 @@ function(d, i) {
       @desc Sets the anchor point around which to rotate the text box.
       @param {Function|[Number, Number]}
    */
-  rotationAnchor(_) {
-    return arguments.length ? (this._rotationAnchor = typeof _ === "function" ? _ : constant(_), this) : this._rotationAnchor;
+  rotateAnchor(_) {
+    return arguments.length ? (this._rotateAnchor = typeof _ === "function" ? _ : constant(_), this) : this._rotateAnchor;
   }
 
   /**

--- a/src/TextBox.js
+++ b/src/TextBox.js
@@ -226,7 +226,7 @@ export default class TextBox extends BaseClass {
     }
 
     function rotate(text) {
-      text.attr("transform", (d, i) => `rotate(${that._rotate(d, i)}, ${d.x + d.w / 2}, ${d.y + d.h / 2})translate(${d.x}, ${d.y})`);
+      text.attr("transform", (d, i) => `translate(${d.x}, ${d.y}) rotate(${that._rotate(d, i)}, ${that._rotationAnchor && that._rotationAnchor(d, i) ? that._rotationAnchor(d, i)[0] : d.w / 2}, ${that._rotationAnchor && that._rotationAnchor(d, i) ? that._rotationAnchor(d, i)[1] : d.h / 2})`);
     }
 
     const update = boxes.enter().append("g")
@@ -493,6 +493,15 @@ function(d, i) {
   */
   rotate(_) {
     return arguments.length ? (this._rotate = typeof _ === "function" ? _ : constant(_), this) : this._rotate;
+  }
+
+  /**
+      @memberof TextBox
+      @desc Sets the anchor point around which to rotate the text box.
+      @param {Function|[Number, Number]}
+   */
+  rotationAnchor(_) {
+    return arguments.length ? (this._rotationAnchor = typeof _ === "function" ? _ : constant(_), this) : this._rotationAnchor;
   }
 
   /**

--- a/src/TextBox.js
+++ b/src/TextBox.js
@@ -52,6 +52,7 @@ export default class TextBox extends BaseClass {
     this._padding = constant(0);
     this._pointerEvents = constant("auto");
     this._rotate = constant(0);
+    this._rotateAnchor = d => [d.w / 2, d.h / 2];
     this._split = textSplit;
     this._text = accessor("text");
     this._textAnchor = constant("start");
@@ -227,10 +228,8 @@ export default class TextBox extends BaseClass {
 
     function rotate(text) {
       text.attr("transform", (d, i) => {
-        const rotateAnchor = that._rotateAnchor && that._rotateAnchor(d, i);
-        const anchorX = rotateAnchor ? rotateAnchor[0] : d.w / 2;
-        const anchorY = rotateAnchor ? rotateAnchor[1] : d.h / 2;
-        return `translate(${d.x}, ${d.y}) rotate(${that._rotate(d, i)}, ${anchorX}, ${anchorY})`;
+        const rotateAnchor = that._rotateAnchor(d, i);
+        return `translate(${d.x}, ${d.y}) rotate(${that._rotate(d, i)}, ${rotateAnchor[0]}, ${rotateAnchor[1]})`;
       });
     }
 

--- a/src/TextBox.js
+++ b/src/TextBox.js
@@ -226,7 +226,12 @@ export default class TextBox extends BaseClass {
     }
 
     function rotate(text) {
-      text.attr("transform", (d, i) => `translate(${d.x}, ${d.y}) rotate(${that._rotate(d, i)}, ${that._rotateAnchor && that._rotateAnchor(d, i) ? that._rotateAnchor(d, i)[0] : d.w / 2}, ${that._rotateAnchor && that._rotateAnchor(d, i) ? that._rotateAnchor(d, i)[1] : d.h / 2})`);
+      text.attr("transform", (d, i) => {
+        const rotateAnchor = that._rotateAnchor && that._rotateAnchor(d, i);
+        const anchorX = rotateAnchor ? rotateAnchor[0] : d.w / 2;
+        const anchorY = rotateAnchor ? rotateAnchor[1] : d.h / 2;
+        return `translate(${d.x}, ${d.y}) rotate(${that._rotate(d, i)}, ${anchorX}, ${anchorY})`;
+      });
     }
 
     const update = boxes.enter().append("g")


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->
This PR is needed for [this PR in d3plus-shape](https://github.com/d3plus/d3plus-shape/pull/74) to work and to close [this issue in d3plus-shape](https://github.com/d3plus/d3plus-shape/issues/72).

### Description
<!--- Describe your changes in detail -->
Adds the `.rotationAnchor( )` method to `TextBox`. 

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have documented all new methods.
- [ ] I have written tests for all new methods/functionality.
- [ ] I have written examples for all new methods/functionality.

