### PR TITLE
 Japanese chars should be treated just like Chinese.

### DIFF
--- a/src/textSplit.js
+++ b/src/textSplit.js
@@ -40,10 +40,9 @@ const japaneseRange = "\u3040-\u309f\u30a0-\u30ff\uff00-\uff0b\uff0d-\uff5d\uff5
 const chineseRange = "\u3400-\u9FBF";
 const laoRange = "\u0E81-\u0EAE\u0EB0-\u0EC4\u0EC8-\u0ECB\u0ECD-\u0EDD";
 
-const noSpaceRange = burmeseRange + chineseRange + laoRange;
+const noSpaceRange = burmeseRange + chineseRange + japaneseRange + laoRange;
 
 const splitWords = new RegExp(`(\\${splitChars.join("|\\")})*[^\\s|\\${splitChars.join("|\\")}]*(\\${splitChars.join("|\\")})*`, "g");
-const japaneseChars = new RegExp(`[${japaneseRange}]`);
 const noSpaceLanguage = new RegExp(`[${noSpaceRange}]`);
 const splitAllChars = new RegExp(`(\\${prefixChars.join("|\\")})*[${noSpaceRange}](\\${suffixChars.join("|\\")}|\\${combiningMarks.join("|\\")})*|[a-z0-9]+`, "gi");
 
@@ -55,7 +54,7 @@ const splitAllChars = new RegExp(`(\\${prefixChars.join("|\\")})*[${noSpaceRange
 export default function(sentence) {
   if (!noSpaceLanguage.test(sentence)) return stringify(sentence).match(splitWords).filter(w => w.length);
   return merge(stringify(sentence).match(splitWords).map(d => {
-    if (!japaneseChars.test(d) && noSpaceLanguage.test(d)) return d.match(splitAllChars);
+    if (noSpaceLanguage.test(d)) return d.match(splitAllChars);
     return [d];
   }));
 }

--- a/test/textSplit.js
+++ b/test/textSplit.js
@@ -21,6 +21,9 @@ test("textSplit", assert => {
   const burmese = textSplit("ကြောယ်။");
   assert.ok(burmese[0] === "ကြော" && burmese[1] === "ယ်။", "burmese");
 
+  const japanese = textSplit("暑い。");
+  assert.ok(japanese[0] === "暑" && japanese[1] === "い。", "japanese");
+
   const lao = textSplit("ຕໍ່ດ້.");
   assert.ok(lao[0] === "ຕໍ່" && lao[1] === "ດ້.", "lao");
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->
As stated in issue #96 , Japanese should be regarded as a "no space language",
and separate treatment from Chinese language is unnecessary.

### Description
<!--- Describe your changes in detail -->
Concatenated ``japaneseRange`` var into `noSpaceRange` and removed test for ``!japaneseChars.test(d)``.
Fortunately, since Japanese shares separation characters with Chinese,
there was apparently no need to augment ``splitChars``.

Also added a minimal test following Chinese, Lao, Burmese examples.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have documented all new methods.
- [ ] I have written tests for all new methods/functionality.
- [ ] I have written examples for all new methods/functionality.

