### PR TITLE
fixes text rotation

### DIFF
--- a/src/TextBox.js
+++ b/src/TextBox.js
@@ -275,7 +275,6 @@ export default class TextBox extends BaseClass {
             .attr("y", (t, i) => d.r === 0 || d.vA === "top" ? `${(i + 1) * d.lH - (d.lH - d.fS)}px` : 
               d.vA === "middle" ? `${(d.h + d.fS) / 2 + (d.fS - d.lH)}px` : `${d.h - 2 * (d.lH - d.fS)}px`);
 
-          console.log((d.h + d.fS) / 2 + (d.fS - d.lH))
         }
 
         const texts = select(this).selectAll("text").data(d.lines);

--- a/src/TextBox.js
+++ b/src/TextBox.js
@@ -276,9 +276,6 @@ export default class TextBox extends BaseClass {
               vA === "middle" ? `${(d.h + d.fS) / 2 + (d.fS - d.lH)}px` : `${d.h - 2 * (d.lH - d.fS)}px`);
         }
 
-
-        //.attr("y", (t, i) => d.r === 0 ? (i + 1) * d.lH - (d.lH - d.fS) : (vA = this$1._verticalAlign(t, i), vA === "middle" ? d.h / 2 + d.fS / 2 : vA === "start" ? d.h : d.lH - (d.lH - d.fS)) );
-
         const texts = select(this).selectAll("text").data(d.lines);
 
         if (that._duration === 0) {

--- a/src/TextBox.js
+++ b/src/TextBox.js
@@ -272,7 +272,8 @@ export default class TextBox extends BaseClass {
             .attr("font-weight", d.fW)
             .style("font-weight", d.fW)
             .attr("x", `${d.tA === "middle" ? d.w / 2 : rtl ? d.tA === "start" ? d.w : 0 : d.tA === "end" ? d.w : 0}px`)
-            .attr("y", (t, i) => d.r === 0 || vA === "top" ? `${(i + 1) * d.lH - (d.lH - d.fS)}px` : vA === "middle" ? `${(d.h + d.fS) / 2 + (d.fS - d.lH)}px` : `${d.h - 2 * (d.lH - d.fS)}px`);
+            .attr("y", (t, i) => d.r === 0 || vA === "top" ? `${(i + 1) * d.lH - (d.lH - d.fS)}px` : 
+              vA === "middle" ? `${(d.h + d.fS) / 2 + (d.fS - d.lH)}px` : `${d.h - 2 * (d.lH - d.fS)}px`);
         }
 
 

--- a/src/TextBox.js
+++ b/src/TextBox.js
@@ -273,9 +273,9 @@ export default class TextBox extends BaseClass {
             .style("font-weight", d.fW)
             .attr("x", `${d.tA === "middle" ? d.w / 2 : rtl ? d.tA === "start" ? d.w : 0 : d.tA === "end" ? d.w : 2 * Math.sin(Math.PI * d.r / 180)}px`)
             .attr("y", (t, i) => d.r === 0 || d.vA === "top" ? `${(i + 1) * d.lH - (d.lH - d.fS)}px` : 
-              d.vA === "middle" ? `${d.h / 2 + d.fS / 2 - (d.lH - d.fS)}px` : `${d.h - 2 * (d.lH - d.fS) - (d.lines.length - (i + 1)) * d.lH}px`);
-//i * d.lH + (d.h + d.fS) / 2 + (d.fS - d.lH)
-              console.log(d)
+              d.vA === "middle" ? 
+                `${(d.h + d.fS) / 2 - (d.lH - d.fS) - (i - d.lines.length / 2 + 0.5) * d.lH}px` : 
+                `${d.h - 2 * (d.lH - d.fS) - (d.lines.length - (i + 1)) * d.lH + 2 * Math.cos(Math.PI * d.r / 180)}px`);
 
         }
 

--- a/src/TextBox.js
+++ b/src/TextBox.js
@@ -271,7 +271,7 @@ export default class TextBox extends BaseClass {
             .style("font-size", `${d.fS}px`)
             .attr("font-weight", d.fW)
             .style("font-weight", d.fW)
-            .attr("x", `${d.tA === "middle" ? d.w / 2 : rtl ? d.tA === "start" ? d.w : 0 : d.tA === "end" ? d.w : 0}px`)
+            .attr("x", `${d.tA === "middle" ? d.w / 2 : rtl ? d.tA === "start" ? d.w : 0 : d.tA === "end" ? d.w : 2 * Math.sin(Math.PI * d.r / 180)}px`)
             .attr("y", (t, i) => d.r === 0 || d.vA === "top" ? `${(i + 1) * d.lH - (d.lH - d.fS)}px` : 
               d.vA === "middle" ? `${d.h / 2 + d.fS / 2 - (d.lH - d.fS)}px` : `${d.h - 2 * (d.lH - d.fS) - (d.lines.length - (i + 1)) * d.lH}px`);
 //i * d.lH + (d.h + d.fS) / 2 + (d.fS - d.lH)

--- a/src/TextBox.js
+++ b/src/TextBox.js
@@ -204,6 +204,7 @@ export default class TextBox extends BaseClass {
           fW: style["font-weight"],
           id: this._id(d, i),
           tA: this._textAnchor(d, i),
+          vA: this._verticalAlign(d, i),
           widths: wrapResults.widths,
           fS, lH, w, h, r,
           x: this._x(d, i) + padding.left,
@@ -250,14 +251,13 @@ export default class TextBox extends BaseClass {
 
     update
       .style("pointer-events", d => this._pointerEvents(d.data, d.i))
-      .each(function(d, i) {
+      .each(function(d) {
 
         /**
             Styles to apply to each <text> element.
             @private
         */
         function textStyle(text) {
-          const vA = this._verticalAlign(d, i);
 
           text
             .text(t => trimRight(t))
@@ -272,8 +272,10 @@ export default class TextBox extends BaseClass {
             .attr("font-weight", d.fW)
             .style("font-weight", d.fW)
             .attr("x", `${d.tA === "middle" ? d.w / 2 : rtl ? d.tA === "start" ? d.w : 0 : d.tA === "end" ? d.w : 0}px`)
-            .attr("y", (t, i) => d.r === 0 || vA === "top" ? `${(i + 1) * d.lH - (d.lH - d.fS)}px` : 
-              vA === "middle" ? `${(d.h + d.fS) / 2 + (d.fS - d.lH)}px` : `${d.h - 2 * (d.lH - d.fS)}px`);
+            .attr("y", (t, i) => d.r === 0 || d.vA === "top" ? `${(i + 1) * d.lH - (d.lH - d.fS)}px` : 
+              d.vA === "middle" ? `${(d.h + d.fS) / 2 + (d.fS - d.lH)}px` : `${d.h - 2 * (d.lH - d.fS)}px`);
+
+          console.log((d.h + d.fS) / 2 + (d.fS - d.lH))
         }
 
         const texts = select(this).selectAll("text").data(d.lines);

--- a/src/TextBox.js
+++ b/src/TextBox.js
@@ -189,7 +189,8 @@ export default class TextBox extends BaseClass {
       if (lineData.length) {
 
         const tH = line * lH;
-        let yP = vA === "top" ? 0 : vA === "middle" ? h / 2 - tH / 2 : h - tH;
+        const r = this._rotate(d, i);
+        let yP = r === 0 ? vA === "top" ? 0 : vA === "middle" ? h / 2 - tH / 2 : h - tH : 0;
         yP -= lH * 0.1;
 
         arr.push({
@@ -202,10 +203,9 @@ export default class TextBox extends BaseClass {
           fO: this._fontOpacity(d, i),
           fW: style["font-weight"],
           id: this._id(d, i),
-          r: this._rotate(d, i),
           tA: this._textAnchor(d, i),
           widths: wrapResults.widths,
-          fS, lH, w, h,
+          fS, lH, w, h, r,
           x: this._x(d, i) + padding.left,
           y: this._y(d, i) + yP + padding.top
         });
@@ -250,13 +250,15 @@ export default class TextBox extends BaseClass {
 
     update
       .style("pointer-events", d => this._pointerEvents(d.data, d.i))
-      .each(function(d) {
+      .each(function(d, i) {
 
         /**
             Styles to apply to each <text> element.
             @private
         */
         function textStyle(text) {
+          const vA = this._verticalAlign(d, i);
+
           text
             .text(t => trimRight(t))
             .attr("aria-hidden", d.aH)
@@ -270,8 +272,11 @@ export default class TextBox extends BaseClass {
             .attr("font-weight", d.fW)
             .style("font-weight", d.fW)
             .attr("x", `${d.tA === "middle" ? d.w / 2 : rtl ? d.tA === "start" ? d.w : 0 : d.tA === "end" ? d.w : 0}px`)
-            .attr("y", (t, i) => `${(i + 1) * d.lH - (d.lH - d.fS)}px`);
+            .attr("y", (t, i) => d.r === 0 || vA === "top" ? `${(i + 1) * d.lH - (d.lH - d.fS)}px` : vA === "middle" ? `${(d.h + d.fS) / 2 + (d.fS - d.lH)}px` : `${d.h - 2 * (d.lH - d.fS)}px`);
         }
+
+
+        //.attr("y", (t, i) => d.r === 0 ? (i + 1) * d.lH - (d.lH - d.fS) : (vA = this$1._verticalAlign(t, i), vA === "middle" ? d.h / 2 + d.fS / 2 : vA === "start" ? d.h : d.lH - (d.lH - d.fS)) );
 
         const texts = select(this).selectAll("text").data(d.lines);
 

--- a/src/TextBox.js
+++ b/src/TextBox.js
@@ -274,7 +274,7 @@ export default class TextBox extends BaseClass {
             .attr("x", `${d.tA === "middle" ? d.w / 2 : rtl ? d.tA === "start" ? d.w : 0 : d.tA === "end" ? d.w : 2 * Math.sin(Math.PI * d.r / 180)}px`)
             .attr("y", (t, i) => d.r === 0 || d.vA === "top" ? `${(i + 1) * d.lH - (d.lH - d.fS)}px` : 
               d.vA === "middle" ? 
-                `${(d.h + d.fS) / 2 - (d.lH - d.fS) - (i - d.lines.length / 2 + 0.5) * d.lH}px` : 
+                `${(d.h + d.fS) / 2 - (d.lH - d.fS) + (i - d.lines.length / 2 + 0.5) * d.lH}px` : 
                 `${d.h - 2 * (d.lH - d.fS) - (d.lines.length - (i + 1)) * d.lH + 2 * Math.cos(Math.PI * d.r / 180)}px`);
 
         }

--- a/src/TextBox.js
+++ b/src/TextBox.js
@@ -273,7 +273,9 @@ export default class TextBox extends BaseClass {
             .style("font-weight", d.fW)
             .attr("x", `${d.tA === "middle" ? d.w / 2 : rtl ? d.tA === "start" ? d.w : 0 : d.tA === "end" ? d.w : 0}px`)
             .attr("y", (t, i) => d.r === 0 || d.vA === "top" ? `${(i + 1) * d.lH - (d.lH - d.fS)}px` : 
-              d.vA === "middle" ? `${(d.h + d.fS) / 2 + (d.fS - d.lH)}px` : `${d.h - 2 * (d.lH - d.fS)}px`);
+              d.vA === "middle" ? `${d.h / 2 + d.fS / 2 - (d.lH - d.fS)}px` : `${d.h - 2 * (d.lH - d.fS) - (d.lines.length - (i + 1)) * d.lH}px`);
+//i * d.lH + (d.h + d.fS) / 2 + (d.fS - d.lH)
+              console.log(d)
 
         }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->
(closes d3plus/d3plus-shape#83)

### Description
<!--- Describe your changes in detail -->
This bug was caused when rotation angle was different to zero. 

For to solve it, I created a different behavior in for `y` position in textSyle function and in `yP` when angle of rotation is different to zero. I tested it using `verticalAlign`: `top`, `middle` and `bottom`.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have documented all new methods.
- [ ] I have written tests for all new methods/functionality.
- [ ] I have written examples for all new methods/functionality.

