### PR TITLE
forces conversion to string inside trim function

### DIFF
--- a/src/trim.js
+++ b/src/trim.js
@@ -4,7 +4,7 @@
     @param {String} str
 */
 function trim(str) {
-  return str.replace(/^\s+|\s+$/g, "");
+  return str.toString().replace(/^\s+|\s+$/g, "");
 }
 
 /**
@@ -13,7 +13,7 @@ function trim(str) {
     @param {String} str
 */
 function trimLeft(str) {
-  return str.replace(/^\s+/, "");
+  return str.toString().replace(/^\s+/, "");
 }
 
 /**
@@ -22,7 +22,7 @@ function trimLeft(str) {
     @param {String} str
 */
 function trimRight(str) {
-  return str.replace(/\s+$/, "");
+  return str.toString().replace(/\s+$/, "");
 }
 
 export {trim, trimLeft, trimRight};


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->
Updating `d3plus-text` to the latest version, I noticed a minor bug implementing the new function `trim()`, because sometimes you could pass a number (like years), and that value broke the code.

### Description
<!--- Describe your changes in detail -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have documented all new methods.
- [ ] I have written tests for all new methods/functionality.
- [ ] I have written examples for all new methods/functionality.

