### PR TITLE
inherit transition from this._select instead of global one to work on…

### DIFF
--- a/src/TextBox.js
+++ b/src/TextBox.js
@@ -230,7 +230,7 @@ export default class TextBox extends BaseClass {
 
     }, []), d => this._id(d.data, d.i));
 
-    const t = transition().duration(this._duration);
+    const t = this._select.transition().duration(this._duration);
 
     if (this._duration === 0) {
 


### PR DESCRIPTION
… shadow DOM

<!--- Provide a general summary of your changes in the title above -->

### Description
<!--- Describe your changes in detail -->
fix #129

When work on shadow DOM the ordinarily *global* transition() will cause `error: transition 1 not found` which are generally due to a detached selection. To inherit transition parameters a proper way is defining a root transition on a root selection as explained by [mbostock](https://github.com/d3/d3-transition/issues/116#issuecomment-685845233).

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have documented all new methods.
- [ ] I have written tests for all new methods/functionality.
- [ ] I have written examples for all new methods/functionality.

